### PR TITLE
bump version to 3.6.4

### DIFF
--- a/app/code/community/Pay/Payment/etc/config.xml
+++ b/app/code/community/Pay/Payment/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Pay_Payment>
-            <version>3.6.3</version>
+            <version>3.6.4</version>
         </Pay_Payment>
     </modules>
 


### PR DESCRIPTION
Release 3.6.4 heeft in etc/config.xml geen bijgewerkte versie en staat nog op 3.6.3