### PR TITLE
Add payment method Klarna KP and change the names for Billink and in3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SOFORT | PostePay | Gezondheidsbon | Capayable Gespreid betalen | Pay Fixed Pric
 Maestro | Dankort | Fashion Giftcard | Klarna | Instore Payments (POS) |
 Bank Transfer | Cartasi | GivaCard | SprayPay | Przelewy24 | 
 | Tikkie | | YourGift | Creditclick | | 
-| | | Paysafecard |
+| eps-Überweisung | | Paysafecard |
 
 
 ### Quickstart

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ With this plug-in by Pay.nl you can easily add all desired payment methods to yo
 Bank Payments  | Creditcards | Gift cards & Vouchers | Pay by invoice | Others | 
 :-----------: | :-----------: | :-----------: | :-----------: | :-----------: |
 iDEAL + QR |Visa | VVV Cadeaukaart | AfterPay | PayPal |
-Bancontact + QR |  Mastercard | Webshop Giftcard | Billink | WeChatPay | 
+Bancontact + QR |  Mastercard | Webshop Giftcard | Achteraf betalen via Billink | WeChatPay | 
 Giropay |American Express | FashionCheque |Focum AchterafBetalen.nl | AmazonPay |
-MyBank | Carte Bancaire | Podium Cadeaukaart | Capayable Achteraf Betalen | Cashly | 
+MyBank | Carte Bancaire | Podium Cadeaukaart | in3 keer betalen, 0% rente | Cashly | 
 SOFORT | PostePay | Gezondheidsbon | Capayable Gespreid betalen | Pay Fixed Price (phone) |
 Maestro | Dankort | Fashion Giftcard | Klarna | Instore Payments (POS) |
 Bank Transfer | Cartasi | GivaCard | SprayPay | Przelewy24 | 

--- a/app/code/community/Pay/Payment/Block/Form/Billink.php
+++ b/app/code/community/Pay/Payment/Block/Form/Billink.php
@@ -3,7 +3,7 @@
 class Pay_Payment_Block_Form_Billink extends Pay_Payment_Block_Form_Abstract {
 
     protected $paymentMethodId = Pay_Payment_Model_Paymentmethod_Billink::OPTION_ID;
-    protected $paymentMethodName = 'Billink';
+    protected $paymentMethodName = 'Achteraf betalen via Billink';
     protected $methodCode = 'pay_payment_billink';
 
     protected $template = 'pay/payment/form/default.phtml';

--- a/app/code/community/Pay/Payment/Block/Form/CapayableGespreid.php
+++ b/app/code/community/Pay/Payment/Block/Form/CapayableGespreid.php
@@ -3,7 +3,7 @@
 class Pay_Payment_Block_Form_CapayableGespreid extends Pay_Payment_Block_Form_Abstract {
 
     protected $paymentMethodId = Pay_Payment_Model_Paymentmethod_CapayableGespreid::OPTION_ID;
-    protected $paymentMethodName = 'Capayable Gespreid';
+    protected $paymentMethodName = 'in3 keer betalen, 0% rente';
 
     protected $methodCode = 'pay_payment_capayablegespreid';
 

--- a/app/code/community/Pay/Payment/Block/Form/Klarnakp.php
+++ b/app/code/community/Pay/Payment/Block/Form/Klarnakp.php
@@ -1,0 +1,9 @@
+<?php
+
+class Pay_Payment_Block_Form_Klarnakp extends Pay_Payment_Block_Form_Abstract {
+
+    protected $paymentMethodId = Pay_Payment_Model_Paymentmethod_Klarnakp::OPTION_ID;
+    protected $paymentMethodName = 'Klarna KP';
+
+    protected $methodCode = 'pay_payment_klarnakp';
+}

--- a/app/code/community/Pay/Payment/Helper/Data.php
+++ b/app/code/community/Pay/Payment/Helper/Data.php
@@ -403,7 +403,7 @@ class Pay_Payment_Helper_Data extends Mage_Core_Helper_Abstract
 
         $arrUsedOptionIds = array();
         foreach ($paymentMethods as $paymentMethod) {
-            $image = 'https://www.pay.nl/images/payment_profiles/20x20/' . $paymentMethod['id'] . '.png';
+            $image = 'https://static.pay.nl/payment_profiles/20x20/' . $paymentMethod['id'] . '.png';
 
             /**
              * @var Pay_Payment_Model_Option $objOption

--- a/app/code/community/Pay/Payment/Model/Paymentmethod/Klarnakp.php
+++ b/app/code/community/Pay/Payment/Model/Paymentmethod/Klarnakp.php
@@ -1,0 +1,8 @@
+<?php
+class Pay_Payment_Model_Paymentmethod_Klarnakp extends Pay_Payment_Model_Paymentmethod {
+    const OPTION_ID = 2265;
+    protected $_paymentOptionId = 2265;
+    protected $_code = 'pay_payment_klarnakp';
+    protected $_formBlockType = 'pay_payment/form_klarnakp';
+}
+    

--- a/app/code/community/Pay/Payment/Model/Source/Paymentmethod/Klarnakp/Active.php
+++ b/app/code/community/Pay/Payment/Model/Source/Paymentmethod/Klarnakp/Active.php
@@ -1,0 +1,4 @@
+<?php
+class Pay_Payment_Model_Source_Paymentmethod_Klarnakp_Active extends Pay_Payment_Model_Source_Paymentmethod_Active{
+    protected $_option_id = Pay_Payment_Model_Paymentmethod_Klarnakp::OPTION_ID;
+}

--- a/app/code/community/Pay/Payment/etc/config.xml
+++ b/app/code/community/Pay/Payment/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Pay_Payment>
-            <version>3.13.4</version>
+            <version>3.13.5</version>
         </Pay_Payment>
     </modules>
     <global>
@@ -276,6 +276,19 @@
                 <limit_shipping>0</limit_shipping>
                 <only_equal_addresses>1</only_equal_addresses>
             </pay_payment_klarna>
+            <pay_payment_klarnakp>
+                <active>0</active>
+                <invoice_email>1</invoice_email>
+                <model>pay_payment/Paymentmethod_Klarnakp</model>
+                <title>Klarna KP</title>
+                <payment_action>authorize</payment_action>
+                <order_status>pending_payment</order_status>
+                <order_status_success>processing</order_status_success>
+                <order_status_verify>pending_payment</order_status_verify>
+                <send_mail>success</send_mail>
+                <limit_shipping>0</limit_shipping>
+                <only_equal_addresses>1</only_equal_addresses>
+            </pay_payment_klarnakp>
             <pay_payment_bitcoin>
                 <active>0</active>
                 <invoice_email>1</invoice_email>
@@ -305,7 +318,7 @@
                 <active>0</active>
                 <invoice_email>1</invoice_email>
                 <model>pay_payment/Paymentmethod_CapayableGespreid</model>
-                <title>Capayable Gespreid</title>
+                <title>in3 keer betalen, 0% rente</title>
                 <payment_action>authorize</payment_action>
                 <order_status>pending_payment</order_status>
                 <order_status_success>processing</order_status_success>
@@ -672,7 +685,7 @@
                 <active>0</active>
                 <invoice_email>1</invoice_email>
                 <model>pay_payment/Paymentmethod_Billink</model>
-                <title>Billink</title>
+                <title>Achteraf betalen via Billink</title>
                 <payment_action>authorize</payment_action>
                 <order_status>pending_payment</order_status>
                 <order_status_success>processing</order_status_success>

--- a/app/code/community/Pay/Payment/etc/system.xml
+++ b/app/code/community/Pay/Payment/etc/system.xml
@@ -5043,7 +5043,7 @@
                     </fields>
                 </pay_payment_dankort>
                 <pay_payment_eps type="group" translate="label" module="pay_payment">
-                    <label>Eps-Überweisung</label>
+                    <label>eps-Überweisung</label>
                     <model>pay_payment/Model_Paymentmethod_Eps</model>
                     <sort_order>1800</sort_order>
                     <show_in_default>1</show_in_default>

--- a/app/code/community/Pay/Payment/etc/system.xml
+++ b/app/code/community/Pay/Payment/etc/system.xml
@@ -5042,6 +5042,302 @@
                         </instructions>
                     </fields>
                 </pay_payment_dankort>
+                <pay_payment_eps type="group" translate="label" module="pay_payment">
+                    <label>Eps-Überweisung</label>
+                    <model>pay_payment/Model_Paymentmethod_Eps</model>
+                    <sort_order>1800</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <active translate="label">
+                            <label>Actief</label>
+                            <comment>Wilt u deze betaalmethode gebruiken</comment>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_paymentmethod_eps_active</source_model>
+                            <config_path>payment/pay_payment_eps/active</config_path>
+                        </active>
+                        <title translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Titel van de betaalmethode</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/title</config_path>
+                        </title>
+                        <sort_order translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Betaalmethode sorteer volgorde</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>4</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/sort_order</config_path>
+                        </sort_order>
+                        <min_order_total translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Minimum bedrag</label>
+                            <comment>Het minimum bedrag waarvoor deze betaalmethode gebruikt mag worden</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/min_order_total</config_path>
+                        </min_order_total>
+                        <max_order_total translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Maximum bedrag</label>
+                            <comment>Het maximum bedrag waarvoor deze betaalmethode gebruikt mag worden
+                            </comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/max_order_total</config_path>
+                        </max_order_total>
+                        <allowspecific translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Beschikbaarheid per land</label>
+                            <frontend_type>allowspecific</frontend_type>
+                            <source_model>adminhtml/system_config_source_payment_allspecificcountries
+                            </source_model>
+                            <sort_order>7</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/allowspecific</config_path>
+                        </allowspecific>
+                        <specificcountry translate="label">
+                            <depends>
+                                <active>1</active>
+                                <allowspecific>1</allowspecific>
+                            </depends>
+                            <label>Toegestane landen</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_country</source_model>
+                            <sort_order>8</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Selecteer de landen waarvoor deze betaalmethode beschikbaar is</comment>
+                            <config_path>payment/pay_payment_eps/specificcountry</config_path>
+                        </specificcountry>
+                        <limit_currency translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Valutas blokkeren</label>
+                            <comment>Schakel dit in als u deze betaalmethode wilt blokkeren voor bepaalde valutas</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/limit_currency</config_path>
+                        </limit_currency>
+                        <specificcurrency translate="label comment">
+                            <depends>
+                                <active>1</active>
+                                <limit_currency>1</limit_currency>
+                            </depends>
+                            <label>Toegestane Valuta's</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_currency</source_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Selecteer de valutas waarvoor deze betaalmethode beschikbaar is</comment>
+                            <config_path>payment/pay_payment_eps/specificcurrency</config_path>
+                        </specificcurrency>
+                        <limit_shipping translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Verzendmethoden blokkeren</label>
+                            <comment>Schakel dit in als u deze betaalmethode wilt blokkeren voor bepaalde verzendmethoden</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>9</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/limit_shipping</config_path>
+                        </limit_shipping>
+                        <disabled_shippingmethods>
+                            <depends>
+                                <active>1</active>
+                                <limit_shipping>1</limit_shipping>
+                            </depends>
+                            <comment>Selecteer de verzendmethoden waarvoor deze betaalmethode NIET beschikbaar is</comment>
+                            <label>Geblokkeerde verzendmethoden</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_shipping_allmethods</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/disabled_shippingmethods</config_path>
+                        </disabled_shippingmethods>
+                        <order_status translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Nieuwe order status</label>
+                            <comment>De status die een order moet krijgen bij het toevoegen</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_pendingPayment</source_model>
+                            <sort_order>11</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/order_status</config_path>
+                        </order_status>
+                        <order_status_success translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Gelukt order status</label>
+                            <comment>De status die een order moet krijgen na succesvolle betaling</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_processing</source_model>
+                            <sort_order>12</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/order_status_success</config_path>
+                        </order_status_success>
+                        <order_status_verify translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Verify order status</label>
+                            <comment>De status die een order moet krijgen wanneer de transactie gecontroleerd moet worden</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_pendingPayment</source_model>
+                            <sort_order>13</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/order_status_verify</config_path>
+                        </order_status_verify>
+                        <order_status_authorized translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Authorized order status</label>
+                            <comment>De status die een order moet krijgen bij een geauthoriseerde betaling</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_processing</source_model>
+                            <sort_order>15</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/order_status_authorized</config_path>
+                        </order_status_authorized>
+                        <charge_type translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Extra kosten rekenen</label>
+                            <comment>Geef hier aan of u extra kosten wilt rekenen op basis van een percentage van het totaalbedrag of een vast bedrag</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/system_config_source_chargetype</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/charge_type</config_path>
+                        </charge_type>
+                        <charge_value translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Extra kosten</label>
+                            <comment>Geef hier aan hoeveel extra kosten u wilt rekenen, gebruik een punt voor decimalen, als u geen extra kosten wilt rekenen vult u niets in</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>201</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/charge_value</config_path>
+                        </charge_value>
+                        <charge_tax_class translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Btw voor extra kosten</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_shipping_taxclass</source_model>
+                            <sort_order>202</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/charge_tax_class</config_path>
+                        </charge_tax_class>
+                        <send_mail translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Bevestigingsmail sturen</label>
+                            <comment>Wanneer wilt u dat de bevestigingsmail wordt verstuurd</comment>
+                            <sort_order>300</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_sendmail</source_model>
+                            <config_path>payment/pay_payment_eps/send_mail</config_path>
+                        </send_mail>
+                        <invoice_email translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Emailen bij factureren</label>
+                            <comment><![CDATA[Een email sturen met de factuur, LET OP: De email wordt alleen gestuurd als je bovenaan bij Algemene instellingen emailen bij factureren aan hebt staan]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>400</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/invoice_email</config_path>
+                        </invoice_email>
+                        <instructions translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Instructions</label>
+                            <comment><![CDATA[If you want to show instructions to the user, you can add them here]]></comment>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>410</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_eps/instructions</config_path>
+                        </instructions>
+                    </fields>
+                </pay_payment_eps>
                 <pay_payment_fashioncheque type="group" translate="label" module="pay_payment">
                     <label>Fashioncheque</label>
                     <model>pay_payment/Model_Paymentmethod_Fashioncheque</model>

--- a/app/code/community/Pay/Payment/etc/system.xml
+++ b/app/code/community/Pay/Payment/etc/system.xml
@@ -2282,7 +2282,7 @@
                     </fields>
                 </pay_payment_applepay>
                 <pay_payment_billink type="group" translate="label" module="pay_payment">
-                    <label>Billink</label>
+                    <label>Achteraf betalen via Billink</label>
                     <model>pay_payment/Model_Paymentmethod_Billink</model>
                     <sort_order>1300</sort_order>
                     <show_in_default>1</show_in_default>
@@ -3534,7 +3534,7 @@
                     </fields>
                 </pay_payment_cashly>
                 <pay_payment_capayablegespreid type="group" translate="label" module="pay_payment">
-                    <label>Capayable Gespreid</label>
+                    <label>in3 keer betalen, 0% rente</label>
                     <model>pay_payment/Model_Paymentmethod_CapayableGespreid</model>
                     <sort_order>1600</sort_order>
                     <show_in_default>1</show_in_default>
@@ -8378,6 +8378,317 @@
                         </instructions>
                     </fields>
                 </pay_payment_klarna>
+                <pay_payment_klarnakp type="group" translate="label" module="pay_payment">
+                    <label>Klarna KP</label>
+                    <model>pay_payment/Model_Paymentmethod_Klarnakp</model>
+                    <sort_order>2750</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <active translate="label">
+                            <label>Actief</label>
+                            <comment>Wilt u deze betaalmethode gebruiken</comment>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_paymentmethod_klarnakp_active</source_model>
+                            <config_path>payment/pay_payment_klarnakp/active</config_path>
+                        </active>
+                        <title translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Titel van de betaalmethode</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/title</config_path>
+                        </title>
+                        <sort_order translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Betaalmethode sorteer volgorde</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>4</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/sort_order</config_path>
+                        </sort_order>
+                        <min_order_total translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Minimum bedrag</label>
+                            <comment>Het minimum bedrag waarvoor deze betaalmethode gebruikt mag worden</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/min_order_total</config_path>
+                        </min_order_total>
+                        <max_order_total translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Maximum bedrag</label>
+                            <comment>Het maximum bedrag waarvoor deze betaalmethode gebruikt mag worden</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>6</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/max_order_total</config_path>
+                        </max_order_total>
+                        <allowspecific translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Beschikbaarheid per land</label>
+                            <frontend_type>allowspecific</frontend_type>
+                            <source_model>adminhtml/system_config_source_payment_allspecificcountries
+                            </source_model>
+                            <sort_order>7</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/allowspecific</config_path>
+                        </allowspecific>
+                        <specificcountry translate="label">
+                            <depends>
+                                <active>1</active>
+                                <allowspecific>1</allowspecific>
+                            </depends>
+                            <label>Toegestane landen</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_country</source_model>
+                            <sort_order>8</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Selecteer de landen waarvoor deze betaalmethode beschikbaar is</comment>
+                            <config_path>payment/pay_payment_klarnakp/specificcountry</config_path>
+                        </specificcountry>
+                        <limit_currency translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Valutas blokkeren</label>
+                            <comment>Schakel dit in als u deze betaalmethode wilt blokkeren voor bepaalde valutas</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/limit_currency</config_path>
+                        </limit_currency>
+                        <specificcurrency translate="label comment">
+                            <depends>
+                                <active>1</active>
+                                <limit_currency>1</limit_currency>
+                            </depends>
+                            <label>Toegestane Valuta's</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_currency</source_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Selecteer de valutas waarvoor deze betaalmethode beschikbaar is</comment>
+                            <config_path>payment/pay_payment_klarnakp/specificcurrency</config_path>
+                        </specificcurrency>
+                        <only_equal_addresses>
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Gelijke verzend- en factuuradressen</label>
+                            <comment>Schakel dit in als het verzend en factuuradres gelijk aan elkaar moeten zijn</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>110</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/only_equal_addresses</config_path>
+                        </only_equal_addresses>
+                        <limit_shipping translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Verzendmethoden blokkeren</label>
+                            <comment>
+                                Schakel dit in als u deze betaalmethode wilt blokkeren voor bepaalde verzendmethoden
+                            </comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>9</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/limit_shipping</config_path>
+                        </limit_shipping>
+                        <disabled_shippingmethods>
+                            <depends>
+                                <active>1</active>
+                                <limit_shipping>1</limit_shipping>
+                            </depends>
+                            <comment>Selecteer de verzendmethoden waarvoor deze betaalmethode NIET beschikbaar is</comment>
+                            <label>Geblokkeerde verzendmethoden</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>adminhtml/system_config_source_shipping_allmethods</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/disabled_shippingmethods</config_path>
+                        </disabled_shippingmethods>
+                        <order_status translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Nieuwe order status</label>
+                            <comment>De status die een order moet krijgen bij het toevoegen</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_pendingPayment</source_model>
+                            <sort_order>11</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/order_status</config_path>
+                        </order_status>
+                        <order_status_success translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Gelukt order status</label>
+                            <comment>De status die een order moet krijgen na succesvolle betaling</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_processing</source_model>
+                            <sort_order>12</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/order_status_success</config_path>
+                        </order_status_success>
+                        <order_status_verify translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Verify order status</label>
+                            <comment>De status die een order moet krijgen wanneer de transactie gecontroleerd moet worden</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_pendingPayment</source_model>
+                            <sort_order>13</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/order_status_verify</config_path>
+                        </order_status_verify>
+                        <order_status_authorized translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Authorized order status</label>
+                            <comment>De status die een order moet krijgen bij een geauthoriseerde betaling</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_status_processing</source_model>
+                            <sort_order>15</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/order_status_authorized</config_path>
+                        </order_status_authorized>
+                        <charge_type translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Extra kosten rekenen</label>
+                            <comment>Geef hier aan of u extra kosten wilt rekenen op basis van een percentage van het totaalbedrag of een vast bedrag</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/system_config_source_chargetype</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/charge_type</config_path>
+                        </charge_type>
+                        <charge_value translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Extra kosten</label>
+                            <comment>Geef hier aan hoeveel extra kosten u wilt rekenen, gebruik een punt voor decimalen, als u geen extra kosten wilt rekenen vult u niets in</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>201</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/charge_value</config_path>
+                        </charge_value>
+                        <charge_tax_class translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Btw voor extra kosten</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_shipping_taxclass</source_model>
+                            <sort_order>202</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/charge_tax_class</config_path>
+                        </charge_tax_class>
+                        <send_mail translate="label">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Bevestigingsmail sturen</label>
+                            <comment>Wanneer wilt u dat de bevestigingsmail wordt verstuurd</comment>
+                            <sort_order>300</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <frontend_type>select</frontend_type>
+                            <source_model>pay_payment/source_sendmail</source_model>
+                            <config_path>payment/pay_payment_klarnakp/send_mail</config_path>
+                        </send_mail>
+                        <invoice_email translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Emailen bij factureren</label>
+                            <comment><![CDATA[Een email sturen met de factuur, LET OP: De email wordt alleen gestuurd als je bovenaan bij Algemene instellingen emailen bij factureren aan hebt staan]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>400</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/invoice_email</config_path>
+                        </invoice_email>
+                        <instructions translate="label comment">
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                            <label>Instructions</label>
+                            <comment><![CDATA[If you want to show instructions to the user, you can add them here]]></comment>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>410</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <config_path>payment/pay_payment_klarnakp/instructions</config_path>
+                        </instructions>
+                    </fields>
+                </pay_payment_klarnakp>
                 <pay_payment_maestro type="group" translate="label" module="pay_payment">
                     <label>Maestro</label>
                     <model>pay_payment/Model_Paymentmethod_Maestro</model>


### PR DESCRIPTION
Wat moet er getest worden:
- Klarna KP correct is toegevoegd
- eps-Uberweising correct is toegevoegd
- De namen van Billink en in3 zijn veranderd naar: "Achteraf betalen via Billink" en "in3 keer betalen, 0% rente". in3 stond nog als Capayable Gespreid in Magento 1
- Images van payment methods in pay.nl settings worden nu via static url ingeladen.