### PR TITLE
Fix indices of AppliedTaxes array of Quote Address Model

### DIFF
--- a/app/code/community/Pay/Payment/Model/Sales/Quote/Address/Total/Paymentcharge.php
+++ b/app/code/community/Pay/Payment/Model/Sales/Quote/Address/Total/Paymentcharge.php
@@ -61,7 +61,7 @@ class Pay_Payment_Model_Sales_Quote_Address_Total_Paymentcharge extends Mage_Sal
                     $arrRate['amount'] = $arrRate['amount'] + $chargeTax;
                     $arrRate['base_amount'] = $arrRate['base_amount'] + $baseChargeTax;
                 }
-              $rates[] = $arrRate;
+              $rates[$arrRate['id']] = $arrRate;
             }
 
 


### PR DESCRIPTION
The indices of the AppliedTaxes array of the Mage_Sales_Model_Quote_Address objects need to be the VAT id's.

In the `Pay_Pa...al_Paymentcharge::collect` the indices are numbered. This causes that `if (isset($ratesIdQuoteItemId[$id]))` in function `Mage_Tax_Model_Observer::salesEventOrderAfterSave` fails and then the Sales_Order_Tax_Item models are not created. This causes various problems throughout the system. We noticed that the VAT summary created by Fooman PDCustomiser was not complete.

Using the Github web editor introduced a newline at the end of the file.